### PR TITLE
Standardize output passing to match expected CMA format

### DIFF
--- a/src/granule_to_sns.py
+++ b/src/granule_to_sns.py
@@ -27,9 +27,11 @@ def generate_message(granule: dict) -> dict:
 
 
 def granule_to_sns(event: dict, _) -> dict:
-    client = boto3.client("sns")
-    granules = event["input"]["granules"]
+    payload = event["input"]
 
+    granules = payload["granules"]
+
+    client = boto3.client("sns")
     sns_topic_arn = os.getenv("SNS_TOPIC_ARN")
 
     for granule in granules:
@@ -46,10 +48,10 @@ def granule_to_sns(event: dict, _) -> dict:
             },
         )
 
-    return event
+    return payload
 
 
-def lambda_handler(event, context):
+def lambda_handler(event: dict, context) -> dict:
     init_root_logger()
     with log_errors():
         return run_cumulus_task(granule_to_sns, event, context)

--- a/tests/test_granule_to_sns.py
+++ b/tests/test_granule_to_sns.py
@@ -105,4 +105,4 @@ def test_generate_message(event, message):
 
 def test_granule_to_sns(sns_client, event, mocker):
     mocker.patch.object(sns_client, "publish", return_value={})
-    assert granule_to_sns(event, None) == event
+    assert granule_to_sns(event, None) == event["input"]


### PR DESCRIPTION
The standard way that cumulus tasks operate is that they expect to pass a payload object around that has a `"granules"` key and possibly some other keys. The default cumulus message config used if you don't specify an override is meant to work with tasks out of the box and would look like this:
```
"task_config": {
  "cumulus_message": {
    "outputs": [
      {
        "source": "{$}",
        "destination": "{$.payload}"
      }
    ]
  }
}
```


Right now in order to use this task, you have to override the default cumulus message processing to set the output like this:
```
"task_config": {
  "cumulus_message": {
    "outputs": [
      {
        "source": "{$.input}",
        "destination": "{$.payload}"
      }
    ]
  }
}
```

After these changes you will be able to use this task without setting any special cumulus message config.